### PR TITLE
use of instead of in to iterate triggers

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1889,7 +1889,7 @@ async function run() {
     let triggered = false;
     
     const prefixOnly = core.getInput("prefix_only") === 'true';
-    for (const trigger in triggers) {
+    for (const trigger of triggers) {
         if ((prefixOnly && body.startsWith(trigger)) || body.includes(trigger)) {
             triggered = true;
             break;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ async function run() {
     let triggered = false;
     
     const prefixOnly = core.getInput("prefix_only") === 'true';
-    for (const trigger in triggers) {
+    for (const trigger of triggers) {
         if ((prefixOnly && body.startsWith(trigger)) || body.includes(trigger)) {
             triggered = true;
             break;


### PR DESCRIPTION
Use `of` instead of `in` to iterate triggers because we want triggers and not indices. 😞 